### PR TITLE
Typegeneralization/nd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ IterativeSolvers = "0.9"
 ProgressMeter = "1.2"
 SparsityOperators = "0.1.7, 0.2"
 VectorizationBase = "0.19, 0.21"
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/ADMM.jl
+++ b/src/ADMM.jl
@@ -69,7 +69,7 @@ function ADMM(A::matT, x::Vector{T}=zeros(eltype(A),size(A,2)); reg=nothing, reg
             , tolInner::Real=1e-5
             , normalizeReg::Bool=false
             , kargs...) where {T,matT,opT}
-
+# TODO: The constructor is not type stable
 
   # unify Floating types
   if typeof(ρ) <: Number

--- a/src/ADMM.jl
+++ b/src/ADMM.jl
@@ -115,8 +115,8 @@ function ADMM(A::matT, x::Vector{T}=zeros(eltype(A),size(A,2)); reg=nothing, reg
 
 
   return ADMM(A,vec(reg),regTrafo,op,β,β_y,x,z,zᵒˡᵈ,u,precon,ρ_vec,iterations
-              ,iterationsInner,statevars, rk,sk,eps_pri,eps_dt,0.0,absTol,relTol,tolInner
-              ,normalizeReg,1.0)
+              ,iterationsInner,statevars, rk,sk,eps_pri,eps_dt,zero(real(T)),absTol,relTol,tolInner
+              ,normalizeReg,one(real(T)))
 end
 
 """
@@ -235,7 +235,7 @@ function iterate(solver::ADMM, iteration::Integer=0)
     copyto!(solver.zᵒˡᵈ[i], solver.z[i])
     solver.z[i][:] .= solver.regTrafo[i]*solver.x .+ solver.u[i]
     if solver.ρ[i] != 0
-      solver.z[i] = solver.reg[i].prox!(solver.z[i], solver.regFac*solver.reg[i].λ/solver.ρ[i]; solver.reg[i].params...)
+      solver.reg[i].prox!(solver.z[i], solver.regFac*solver.reg[i].λ/solver.ρ[i]; solver.reg[i].params...)
     end
   end
 

--- a/src/ADMM.jl
+++ b/src/ADMM.jl
@@ -56,26 +56,26 @@ creates an `ADMM` object for the system matrix `A`.
 * (`relTol::Real=eps()`)     - rel tolerance for stopping criterion
 * (`tolInner::Real=1.e-5`)   - rel tolerance for CG stopping criterion
 """
-function ADMM(A::matT, x::vecT=zeros(eltype(A),size(A,2)); reg=nothing, regName=["L1"]
+function ADMM(A::matT, x::Vector{T}=zeros(eltype(A),size(A,2)); reg=nothing, regName=["L1"]
             , λ=[0.0]
             , regTrafo=nothing
             , AHA::opT=nothing
             , precon=Identity()
             , ρ=[1.e-1]
-            , iterations::Int64=50
-            , iterationsInner::Int64=10
+            , iterations::Integer=50
+            , iterationsInner::Integer=10
             , absTol::Real=eps()
             , relTol::Real=eps()
             , tolInner::Real=1e-5
             , normalizeReg::Bool=false
-            , kargs...) where {matT,vecT,opT}
+            , kargs...) where {T,matT,opT}
 
   if reg == nothing
     reg = Regularization(regName, λ, kargs...)
   end
 
   if regTrafo == nothing
-    regTrafo = [opEye(eltype(x),size(A,2)) for i=1:length(vec(reg))]
+    regTrafo = [LinearOperator{T}(length(x), length(x), true, true, x -> identity(x), x -> identity(x), x -> identity(x)) for i=1:length(vec(reg))]
   end
 
   # fields for primal & dual variables

--- a/src/ADMM.jl
+++ b/src/ADMM.jl
@@ -1,37 +1,37 @@
 export admm
 
-mutable struct ADMM{TC,T,matT,opT,ropT,preconT} <: AbstractLinearSolver where {TC <: Union{T, Complex{T}}}
+mutable struct ADMM{rT,matT,opT,ropT,vecT,rvecT,preconT} <: AbstractLinearSolver where {vecT <: AbstractVector{Union{rT, Complex{rT}}}, rvecT <: AbstractVector{rT}}
   # oerators and regularization
   A::matT
   reg::Vector{Regularization}
   regTrafo::Vector{ropT}
   # fields and operators for x update
   op::opT
-  β::Vector{TC}
-  β_y::Vector{TC}
+  β::vecT
+  β_y::vecT
   # fields for primal & dual variables
-  x::Vector{TC}
-  z::Vector{Vector{TC}}
-  zᵒˡᵈ::Vector{Vector{TC}}
-  u::Vector{Vector{TC}}
+  x::vecT
+  z::Vector{vecT}
+  zᵒˡᵈ::Vector{vecT}
+  u::Vector{vecT}
   # other parameters
   precon::preconT
-  ρ::Vector{T} # TODO: Switch all these vectors to Tuple
+  ρ::rvecT # TODO: Switch all these vectors to Tuple
   iterations::Int64
   iterationsInner::Int64
   # state variables for CG
   cgStateVars::CGStateVariables
   # convergence parameters
-  rᵏ::Vector{T}
-  sᵏ::Vector{TC}
-  ɛᵖʳⁱ::Vector{T}
-  ɛ_dt::Vector{TC}
-  σᵃᵇˢ::T
-  absTol::T
-  relTol::T
-  tolInner::T
+  rᵏ::rvecT
+  sᵏ::vecT
+  ɛᵖʳⁱ::rvecT
+  ɛ_dt::vecT
+  σᵃᵇˢ::rT
+  absTol::rT
+  relTol::rT
+  tolInner::rT
   normalizeReg::Bool
-  regFac::T
+  regFac::rT
 end
 
 """
@@ -128,11 +128,11 @@ end
 
 (re-) initializes the ADMM iterator
 """
-function init!(solver::ADMM{TC,T,matT,opT,ropT,preconT}, b::Vector{TC}
+function init!(solver::ADMM{rT,matT,opT,ropT,vecT,rvecT,preconT}, b::vecT
               ; A::matT=solver.A
               , AHA::opT=solver.op
-              , x::Vector{TC}=similar(b,0)
-              , kargs...) where {TC,T,matT,opT,ropT,preconT}
+              , x::vecT=similar(b,0)
+              , kargs...) where {rT,matT,opT,ropT,vecT,rvecT,preconT}
 
   # operators
   if A != solver.A
@@ -198,7 +198,7 @@ solves an inverse problem using ADMM.
 when a `SolverInfo` objects is passed, the primal residuals `solver.rk`
 and the dual residual `norm(solver.sk)` are stored in `solverInfo.convMeas`.
 """
-function solve(solver::ADMM, b::Vector{TC}; A=solver.A, startVector::Vector{TC}=similar(b,0), solverInfo=nothing, kargs...) where {TC}
+function solve(solver::ADMM{rT,matT,opT,ropT,vecT,rvecT,preconT}, b::vecT; A=solver.A, startVector::vecT=similar(b,0), solverInfo=nothing, kargs...) where {rT,matT,opT,ropT,vecT,rvecT,preconT}
   # initialize solver parameters
   init!(solver, b; A=A, x=startVector)
 

--- a/src/ADMM.jl
+++ b/src/ADMM.jl
@@ -17,8 +17,8 @@ mutable struct ADMM{matT,opT,ropT,vecT,rvecT,preconT} <: AbstractLinearSolver
   # other parameters
   precon::preconT
   ρ::rvecT
-  iterations::Int64
-  iterationsInner::Int64
+  iterations::Integer
+  iterationsInner::Integer
   # state variables for CG
   cgStateVars::CGStateVariables
   # convergence parameters
@@ -26,12 +26,12 @@ mutable struct ADMM{matT,opT,ropT,vecT,rvecT,preconT} <: AbstractLinearSolver
   sᵏ::vecT
   ɛᵖʳⁱ::rvecT
   ɛ_dt::vecT
-  σᵃᵇˢ::Float64
-  absTol::Float64
-  relTol::Float64
-  tolInner::Float64
+  σᵃᵇˢ::Real
+  absTol::Real
+  relTol::Real
+  tolInner::Real
   normalizeReg::Bool
-  regFac::Float64
+  regFac::Real
 end
 
 """
@@ -48,25 +48,25 @@ creates an `ADMM` object for the system matrix `A`.
 * (`λ=[0.0]`)                   - Regularization paramter
 * (`regTrafo=nothing`)          - transformations applied inside each regularizer
 * (`precon=Identity()`)         - preconditionner for the internal CG algorithm
-* (`ρ::Float64=1.e-2`)          - penalty of the augmented lagrangian
+* (`ρ::Real=1.e-2`)          - penalty of the augmented lagrangian
 * (`adaptRho::Bool=false`)      - adapt rho to balance primal and dual feasibility
 * (`iterations::Int64=50`)      - max number of ADMM iterations
 * (`iterationsInner::Int64=10`) - max number of internal CG iterations
-* (`absTol::Float64=eps()`)     - abs tolerance for stopping criterion
-* (`relTol::Float64=eps()`)     - rel tolerance for stopping criterion
-* (`tolInner::Float64=1.e-5`)   - rel tolerance for CG stopping criterion
+* (`absTol::Real=eps()`)     - abs tolerance for stopping criterion
+* (`relTol::Real=eps()`)     - rel tolerance for stopping criterion
+* (`tolInner::Real=1.e-5`)   - rel tolerance for CG stopping criterion
 """
 function ADMM(A::matT, x::vecT=zeros(eltype(A),size(A,2)); reg=nothing, regName=["L1"]
             , λ=[0.0]
-            , regTrafo=nothing 
+            , regTrafo=nothing
             , AHA::opT=nothing
             , precon=Identity()
             , ρ=[1.e-1]
             , iterations::Int64=50
             , iterationsInner::Int64=10
-            , absTol::Float64=eps()
-            , relTol::Float64=eps()
-            , tolInner::Float64=1.e-5
+            , absTol::Real=eps()
+            , relTol::Real=eps()
+            , tolInner::Real=1e-5
             , normalizeReg::Bool=false
             , kargs...) where {matT,vecT,opT}
 
@@ -143,17 +143,17 @@ function init!(solver::ADMM{matT,opT,ropT,vecT,rvecT,preconT}, b::vecT
     if !isempty(b)
       solver.x .= adjoint(A) * b
     else
-      solver.x .= 0.0
-    end
-  else
-    solver.x[:] .= x
-  end
+      solver.x .= 0
+   end
+ else
+   solver.x[:] .= x
+ end
 
   # primal and dual variables
   for i=1:length(solver.reg)
     solver.z[i][:] .= solver.regTrafo[i]*solver.x
-    solver.zᵒˡᵈ[i][:] .= 0.0
-    solver.u[i] .= 0.0
+    solver.zᵒˡᵈ[i][:] .= 0
+    solver.u[i] .= 0
   end
 
   # right hand side for the x-update
@@ -161,7 +161,7 @@ function init!(solver::ADMM{matT,opT,ropT,vecT,rvecT,preconT}, b::vecT
 
   # convergence parameter
   solver.rᵏ .= 0
-  solver.sᵏ .= 0 
+  solver.sᵏ .= 0
   solver.ɛᵖʳⁱ .= 0
   solver.ɛ_dt .= 0
   solver.σᵃᵇˢ = sqrt(length(b))*solver.absTol
@@ -170,7 +170,7 @@ function init!(solver::ADMM{matT,opT,ropT,vecT,rvecT,preconT}, b::vecT
   if solver.normalizeReg
     solver.regFac = norm(b,1)/length(b)
   else
-    solver.regFac = 1.0
+    solver.regFac = 1
   end
 end
 
@@ -213,7 +213,7 @@ end
 
 performs one ADMM iteration.
 """
-function iterate(solver::ADMM{matT,opT,T,preconT}, iteration::Int=0) where {matT,opT,T,preconT}
+function iterate(solver::ADMM{matT,opT,T,preconT}, iteration::Integer=0) where {matT,opT,T,preconT}
   if done(solver, iteration) return nothing end
 
   # 1. solve arg min_x 1/2|| Ax-b ||² + ρ/2 Σ_i||Φi*x+ui-zi||²

--- a/src/ADMM.jl
+++ b/src/ADMM.jl
@@ -235,7 +235,7 @@ function iterate(solver::ADMM{matT,opT,T,preconT}, iteration::Integer=0) where {
     copyto!(solver.zᵒˡᵈ[i], solver.z[i])
     solver.z[i][:] .= solver.regTrafo[i]*solver.x .+ solver.u[i]
     if solver.ρ[i] != 0
-      solver.reg[i].prox!(solver.z[i], solver.regFac*solver.reg[i].λ/solver.ρ[i]; solver.reg[i].params...)
+      solver.z[i] = solver.reg[i].prox!(solver.z[i], solver.regFac*solver.reg[i].λ/solver.ρ[i]; solver.reg[i].params...)
     end
   end
 

--- a/src/proximalMaps/ProxL1.jl
+++ b/src/proximalMaps/ProxL1.jl
@@ -10,9 +10,9 @@ performs soft-thresholding - i.e. proximal map for the Lasso problem.
 * `λ::Float64`                  - regularization paramter
 * `sparseTrafo::Trafo=nothing`  - sparsifying transform to apply
 """
-function proxL1!(x::T, λ::Float64; sparseTrafo::Trafo=nothing, kargs...) where T<:AbstractArray
-  ε = eps(real(eltype(T)))
-  
+function proxL1!(x::AbstractArray{Tc}, λ::T; sparseTrafo::Trafo=nothing, kargs...) where {T, Tc <: Union{T, Complex{T}}}
+  ε = eps(T)
+
   if sparseTrafo != nothing
     z = sparseTrafo*x
     z .= max.((abs.(z).-λ),0) .* (z.+ε)./(abs.(z).+ε)

--- a/src/proximalMaps/ProxLLR.jl
+++ b/src/proximalMaps/ProxLLR.jl
@@ -12,8 +12,8 @@ proximal map for LLR regularization using singular-value-thresholding
 * `blockSize::Tuple{Int}=[2;2]` - size of patches to perform singluar value thresholding on
 * `randshift::Bool=true`        - randomly shifts the patches to ensure translation invariance
 """
-function proxLLR!(x::Vector{T}, λ::Float64=1e-6; shape::NTuple=[],
-   blockSize::Array{Int64,1}=[2; 2], randshift::Bool=true, kargs...) where T
+function proxLLR!(x::Vector{Complex{T}}, λ::T=1e-6; shape::NTuple=[],
+   blockSize::Vector{TI}=[2; 2], randshift::Bool=true, kargs...) where {T, TI <: Integer}
   # xᵖʳᵒˣ = zeros(T,size(x))
   N = prod(shape)
   # K = floor(Int,length(x)/N)
@@ -22,8 +22,8 @@ function proxLLR!(x::Vector{T}, λ::Float64=1e-6; shape::NTuple=[],
   return x
 end
 
-function svt(x::Vector{T}, shape::Tuple, λ::Float64=1e-6;
-   blockSize::Array{Int64,1}=[2; 2], randshift::Bool=true, kargs...) where T
+function svt(x::Vector{Complex{T}}, shape::Tuple, λ::T=1e-6;
+   blockSize::Vector{TI}=[2; 2], randshift::Bool=true, kargs...) where {T, TI <: Integer}
 
   x = reshape( x, tuple( shape...,floor(Int64, length(x)/prod(shape)) ) )
 
@@ -41,7 +41,7 @@ function svt(x::Vector{T}, shape::Tuple, λ::Float64=1e-6;
   # reshape into patches
   L = floor(Int,ny*nz/Wy/Wz) # number of patches, assumes that image dimensions are divisble by the blocksizes
 
-  xᴸᴸᴿ = zeros(T,Wy*Wz,L,K)
+  xᴸᴸᴿ = zeros(Complex{T},Wy*Wz,L,K)
   for i=1:K
     xᴸᴸᴿ[:,:,i] = im2colDistinct(x[:,:,i], (Wy,Wz))
   end
@@ -49,7 +49,7 @@ function svt(x::Vector{T}, shape::Tuple, λ::Float64=1e-6;
 
   # threshold singular values
   for i = 1:L
-    if xᴸᴸᴿ[:,:,i] == zeros(T, Wy*Wz,K)
+    if xᴸᴸᴿ[:,:,i] == zeros(Complex{T}, Wy*Wz,K)
       continue
     end
     SVDec = svd(xᴸᴸᴿ[:,:,i])
@@ -58,7 +58,7 @@ function svt(x::Vector{T}, shape::Tuple, λ::Float64=1e-6;
   end
 
   # reshape into image
-  xᵗʰʳᵉˢʰ = zeros(T,size(x))
+  xᵗʰʳᵉˢʰ = zeros(Complex{T},size(x))
   for i = 1:K
     xᵗʰʳᵉˢʰ[:,:,i] = col2imDistinct( xᴸᴸᴿ[:,i,:], (Wy,Wz), (ny,nz) )
   end
@@ -80,7 +80,7 @@ end
 returns the value of the LLR-regularization term.
 Arguments are the same is in `proxLLR!`
 """
-function normLLR(x::Vector{T}, λ::Float64; shape::NTuple=[], L=1, blockSize::Array{Int64,1}=[2; 2], randshift::Bool=true, kargs...) where T
+function normLLR(x::Vector{T}, λ::Float64; shape::NTuple=[], L=1, blockSize::Vector{TI}=[2; 2], randshift::Bool=true, kargs...) where {T, TI <: Integer}
 
   N = prod(shape)
   K = floor(Int,length(x)/(N*L))
@@ -92,8 +92,8 @@ function normLLR(x::Vector{T}, λ::Float64; shape::NTuple=[], L=1, blockSize::Ar
   return λ*normᴸᴸᴿ
 end
 
-function blockNuclearNorm(x::Vector{T}, shape::Tuple; blockSize::Array{Int64,1}=[2; 2],
-      randshift::Bool=true, kargs...) where T
+function blockNuclearNorm(x::Vector{T}, shape::Tuple; blockSize::Vector{TI}=[2; 2],
+      randshift::Bool=true, kargs...) where {T, TI <: Integer}
     x = reshape( x, tuple( shape...,floor(Int64, length(x)/prod(shape)) ) )
 
     Wy = blockSize[1]

--- a/src/proximalMaps/ProxLLR.jl
+++ b/src/proximalMaps/ProxLLR.jl
@@ -62,20 +62,20 @@ end
 returns the value of the LLR-regularization term.
 Arguments are the same is in `proxLLR!`
 """
-function normLLR(x::Vector{T}, λ::Float64; shape::NTuple, L=1, blockSize::Vector{TI}=[2; 2], randshift::Bool=true, kargs...) where {T, TI <: Integer}
+function normLLR(x::Vector{T}, λ::Float64; shape::NTuple{N,TI}, L=1, blockSize::NTuple{N,TI}=ntuple(_-> 2, N), randshift::Bool=true, kargs...) where {N, T, TI <: Integer}
 
-  N = prod(shape)
-  K = floor(Int,length(x)/(N*L))
+  Nvoxel = prod(shape)
+  K = floor(Int,length(x)/(Nvoxel*L))
   normᴸᴸᴿ = 0.
   for i = 1:L
-    normᴸᴸᴿ +=  blockNuclearNorm(x[(i-1)*N*K+1:i*N*K], shape; blockSize=blockSize, randshift=randshift, kargs...)
+    normᴸᴸᴿ +=  blockNuclearNorm(x[(i-1)*Nvoxel*K+1:i*Nvoxel*K], shape; blockSize=blockSize, randshift=randshift, kargs...)
   end
 
   return λ*normᴸᴸᴿ
 end
 
-function blockNuclearNorm(x::Vector{T}, shape::Tuple; blockSize::Vector{TI}=[2; 2],
-      randshift::Bool=true, kargs...) where {T, TI <: Integer}
+function blockNuclearNorm(x::Vector{T}, shape::NTuple{N,TI}; blockSize::NTuple{N,TI}=ntuple(_-> 2, N),
+      randshift::Bool=true, kargs...) where {N, T, TI <: Integer}
     x = reshape( x, tuple( shape...,floor(Int64, length(x)/prod(shape)) ) )
 
     Wy = blockSize[1]

--- a/src/proximalMaps/ProxLLR.jl
+++ b/src/proximalMaps/ProxLLR.jl
@@ -12,66 +12,48 @@ proximal map for LLR regularization using singular-value-thresholding
 * `blockSize::Tuple{Int}=[2;2]` - size of patches to perform singluar value thresholding on
 * `randshift::Bool=true`        - randomly shifts the patches to ensure translation invariance
 """
-function proxLLR!(x::Vector{Complex{T}}, λ::T=1e-6; shape::NTuple=[],
-   blockSize::Vector{TI}=[2; 2], randshift::Bool=true, kargs...) where {T, TI <: Integer}
-  # xᵖʳᵒˣ = zeros(T,size(x))
-  N = prod(shape)
-  # K = floor(Int,length(x)/N)
-  x[:] = vec( svt(x[:], shape, λ; blockSize=blockSize, randshift=randshift, kargs...) )
+function proxLLR!(x::Vector{T}, λ; shape::NTuple{N,TI}=error(),
+   blockSize::NTuple{N,TI}=ntuple(_-> 2, N), randshift::Bool=true) where {T, N,TI <: Integer}
 
-  return x
-end
+  x = reshape(x, tuple(shape..., length(x) ÷ prod(shape)))
 
-function svt(x::Vector{Complex{T}}, shape::Tuple, λ::T=1e-6;
-   blockSize::Vector{TI}=[2; 2], randshift::Bool=true, kargs...) where {T, TI <: Integer}
-
-  x = reshape( x, tuple( shape...,floor(Int64, length(x)/prod(shape)) ) )
-
-  Wy = blockSize[1]
-  Wz = blockSize[2]
+  block_idx = CartesianIndices(blockSize)
+  K = size(x)[end]
 
   if randshift
     # Random.seed!(1234)
-    shift_idx = [rand(1:Wy) rand(1:Wz) 0]
+    shift_idx = (Tuple(rand(block_idx))..., 0)
     x = circshift(x, shift_idx)
   end
 
-  ny, nz, K = size(x)
-
-  # reshape into patches
-  L = floor(Int,ny*nz/Wy/Wz) # number of patches, assumes that image dimensions are divisble by the blocksizes
-
-  xᴸᴸᴿ = zeros(Complex{T},Wy*Wz,L,K)
-  for i=1:K
-    xᴸᴸᴿ[:,:,i] = im2colDistinct(x[:,:,i], (Wy,Wz))
+  ext = mod.(shape,blockSize)
+  pad = mod.(blockSize .- ext, blockSize)
+  if any(pad .!= 0)
+    x1 = zeros(T, (shape .+ pad)..., K)
+    x1[CartesianIndices(x)] .= x
+  else
+    x1 = x
   end
-  xᴸᴸᴿ = permutedims(xᴸᴸᴿ,[1 3 2])
 
-  # threshold singular values
-  for i = 1:L
-    if xᴸᴸᴿ[:,:,i] == zeros(Complex{T}, Wy*Wz,K)
-      continue
-    end
-    SVDec = svd(xᴸᴸᴿ[:,:,i])
+  xᴸᴸᴿ = Array{T}(undef, prod(blockSize), K)
+  for i ∈ CartesianIndices(StepRange.(0, blockSize, shape .- 1))
+    @views xᴸᴸᴿ .= reshape(x1[i .+ block_idx,:], :, K)
+    # threshold singular values
+    SVDec = svd!(xᴸᴸᴿ)
     proxL1!(SVDec.S,λ)
-    xᴸᴸᴿ[:,:,i] = SVDec.U*Matrix(Diagonal(SVDec.S))*SVDec.Vt
+    x1[i .+ block_idx,:] .= reshape(SVDec.U * Diagonal(SVDec.S) * SVDec.Vt, blockSize..., :)
   end
 
-  # reshape into image
-  xᵗʰʳᵉˢʰ = zeros(Complex{T},size(x))
-  for i = 1:K
-    xᵗʰʳᵉˢʰ[:,:,i] = col2imDistinct( xᴸᴸᴿ[:,i,:], (Wy,Wz), (ny,nz) )
+  if any(pad .!= 0)
+    x = x1[CartesianIndices(x)]
   end
 
   if randshift
-    xᵗʰʳᵉˢʰ = circshift(xᵗʰʳᵉˢʰ, -1*shift_idx)
+    x = circshift(x, -1 .* shift_idx)
   end
 
-  if !isempty(shape)
-    xᵗʰʳᵉˢʰ = reshape( xᵗʰʳᵉˢʰ, prod(shape),floor( Int, length(xᵗʰʳᵉˢʰ)/prod(shape) ) )
-  end
-
-  return xᵗʰʳᵉˢʰ
+  x = vec(x)
+  return x
 end
 
 """
@@ -80,7 +62,7 @@ end
 returns the value of the LLR-regularization term.
 Arguments are the same is in `proxLLR!`
 """
-function normLLR(x::Vector{T}, λ::Float64; shape::NTuple=[], L=1, blockSize::Vector{TI}=[2; 2], randshift::Bool=true, kargs...) where {T, TI <: Integer}
+function normLLR(x::Vector{T}, λ::Float64; shape::NTuple, L=1, blockSize::Vector{TI}=[2; 2], randshift::Bool=true, kargs...) where {T, TI <: Integer}
 
   N = prod(shape)
   K = floor(Int,length(x)/(N*L))

--- a/test/testProxMaps.jl
+++ b/test/testProxMaps.jl
@@ -158,7 +158,7 @@ function testNuclear(N=32,rank=2;σ=0.05)
   @test 0.5*norm(xNoisy-x_lr)^2+normNuclear(x_lr,5*σ,svtShape=(N,N)) <= normNuclear(xNoisy,5*σ,svtShape=(N,N))
 end
 
-function testLLR(shape=(32,32,80),blockSize=[4,4];σ=0.05)
+function testLLR(shape=(32,32,80),blockSize=(4,4);σ=0.05)
   @info "test LLR regularization"
   Random.seed!(1234)
   x = zeros(ComplexF64,shape);

--- a/test/testProxMaps.jl
+++ b/test/testProxMaps.jl
@@ -186,6 +186,36 @@ function testLLR(shape=(32,32,80),blockSize=(4,4);σ=0.05)
   @test 0.5*norm(xNoisy-x_llr)^2+normLLR(x_llr,10*σ,shape=shape[1:2],blockSize=blockSize,randshift=false) <= normLLR(xNoisy,10*σ,shape=shape[1:2],blockSize=blockSize,randshift=false)
 end
 
+function testLLR_3D(shape=(32,32,32,80),blockSize=(4,4,4);σ=0.05)
+  @info "test LLR 3D regularization"
+  Random.seed!(1234)
+  x = zeros(ComplexF64,shape)
+  for k=1:div(shape[3],blockSize[3])
+    for j=1:div(shape[2],blockSize[2])
+      for i=1:div(shape[1],blockSize[1])
+        ampl = rand()
+        r = rand()
+        for t=1:shape[4]
+          x[(i-1)*blockSize[1]+1:i*blockSize[1],(j-1)*blockSize[2]+1:j*blockSize[2],(k-1)*blockSize[3]+1:k*blockSize[3],t] .= ampl*exp.(-r*t)
+        end
+      end
+    end
+  end
+  x = vec(x)
+
+  xNoisy = copy(x)
+  σ = sum(abs.(x))/length(x)*σ
+  xNoisy[:] += σ/sqrt(2.0)*(randn(prod(shape))+1im*randn(prod(shape)))
+
+  x_llr = copy(xNoisy)
+  proxLLR!(x_llr,10*σ,shape=shape[1:end-1],blockSize=blockSize,randshift=false)
+  @test norm(x - x_llr) <= norm(x - xNoisy)
+  @test norm(x - x_llr) / norm(x) ≈ 0 atol=0.05
+  @info "rel. LLR 3D error : $(norm(x - x_llr)/ norm(x)) vs $(norm(x - xNoisy)/ norm(x))"
+  # check decreas of objective function # TODO: Implement norm as ND
+  # @test 0.5*norm(xNoisy-x_llr)^2+normLLR(x_llr,10*σ,shape=shape[1:3],blockSize=blockSize,randshift=false) <= normLLR(xNoisy,10*σ,shape=shape[1:3],blockSize=blockSize,randshift=false)
+end
+
 @testset "Proximal Maps" begin
   testL2Prox()
   testL1Prox()
@@ -195,4 +225,5 @@ end
   testProj()
   testNuclear()
   testLLR()
+  testLLR_3D()
 end


### PR DESCRIPTION
Hi!

I added the following features to the code:

- Relax type restrictions in the ADMM implementation, in `ProxLLR!`, and in `proxL1!` to allow for types other than `Float64`, such as `Float32` etc.
- Change the implementation of `ProxLLR!` to allow for ND-cases. I am not using the function `im2colDistinct` at all anymore, but I rather select a block at a time using `CartesianIndices`, perform the SVD+thresholding, and write back into the original array. This is overall a bit less memory hungry / does not require as many copy operations. Note that I did not change the `normLLR` function (it is still 2D only); I simply did not need it and wanted to hear your opinion on my implementation first. But, of course, it would be nicer to have a uniform implementation. 

The one breaking change I made was to switch `blockSize` from a Vector to an NTuple, which seems more consistent and has speed benefits. I was thinking about switching rho etc. also to Tuples, but I didn't want to introduce major breaking changes. Let me know what you think!

-ja