### PR TITLE
FISTA

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -274,3 +274,38 @@ function nrmsd(I,Ireco)
   NRMS = RMS/(maximum(abs.(I))-minimum(abs.(I)) )
   return NRMS
 end
+
+"""
+    power_iterations(AᴴA; rtol=1e-2, maxiter=30, verbose=false)
+
+Power iterations to determine the maximum eigenvalue of a normal operator or square matrix.
+
+# Arguments
+* `AᴴA`                 - operator or matrix; has to be square
+
+# Keyword Arguments
+* `rtol=1e-2`           - relative tolerance; function terminates if the change of the max. eigenvalue is smaller than this values
+* `maxiter=30`          - maximum number of power iterations
+* `verbose=false`       - print maximum eigenvalue if `true`
+
+# Output
+maximum eigenvalue of the operator
+"""
+function power_iterations(AᴴA; rtol=1e-2, maxiter=30, verbose=false)
+  b = randn(eltype(AᴴA), size(AᴴA,2))
+  bᵒˡᵈ = similar(b)
+  λ = Inf
+
+  for i = 1:maxiter
+    b ./= norm(b)
+    copy!(bᵒˡᵈ, b)
+    mul!(b, AᴴA, bᵒˡᵈ)
+
+    λᵒˡᵈ = λ
+    λ = (bᵒˡᵈ' * b) / (bᵒˡᵈ' * bᵒˡᵈ)
+    verbose && println("iter = $i; λ = $λ")
+    abs(λ/λᵒˡᵈ - 1) < rtol && return λ
+  end
+
+  return λ
+end


### PR DESCRIPTION
Hi,
I made the following modifications to the FISTA algorithm:
* Allow for generic floating point precision. 
* Accept `AHA` operator as keyword argument. For this purpose, I had to re-define the residuum in `x` (e.g. image) space. 
* I undid your trick of iteratively changing the residuum and instead I calculate it from scratch in each iteration. The implementation in this PR comes at the cost of one additional `x` variable in memory, but this avoids an allocation of a temporary array of size `x` in each iterations, so it should be faster. Additionally, I was wondering how bad the accumulation of numerical errors is when accumulating the residuum, especially when using `Float32`. One could genuinely avoid this extra variable when assuming a 5-argument `mul!` implementation of `AHA` and when accepting that we never actually calculate the residuum. So we would have to find a different termination criterion. Thoughts?
* Implemented step size normalization via power iteration: I estimate the largest eigenvalue of AHA multiply the step size with this value. This approach is shamelessly stolen from BART. I suggest to set the normalization flag to true by default and to set the default rho = 0.95 * max_eigenvalue. This change of the default makes this PR breaking, but I think it makes the algorithm much more robust by avoiding a guessing game of rho...

LMK what you think...
-ja