### PR TITLE
FISTA bugfixes & proxLLR speed improvement

### DIFF
--- a/src/FISTA.jl
+++ b/src/FISTA.jl
@@ -139,12 +139,10 @@ function iterate(solver::FISTA, iteration::Int=0)
 
   # momentum / Nesterov step
   # this implementation mimics BART, saving memory by first swapping x and xᵒˡᵈ before calculating x + α * (x - xᵒˡᵈ)
-  @floop for i ∈ eachindex(solver.x) # swap x and xᵒˡᵈ
-    tmp = solver.xᵒˡᵈ[i]
-    solver.xᵒˡᵈ[i] = solver.x[i]
-    solver.x[i] = tmp
-  end
-  solver.x .*= ((1 - solver.tᵒˡᵈ)/solver.t) # here we calculate -α * xᵒˡᵈ, where x is actually xᵒˡᵈ
+  tmp = solver.xᵒˡᵈ
+  solver.xᵒˡᵈ = solver.x
+  solver.x = tmp # swap x and xᵒˡᵈ
+  solver.x .*= ((1 - solver.tᵒˡᵈ)/solver.t) # here we calculate -α * xᵒˡᵈ, where xᵒˡᵈ is now stored in x
   solver.x .+= ((solver.tᵒˡᵈ-1)/solver.t + 1) .* (solver.xᵒˡᵈ) # add (α+1)*x, where x is now stored in xᵒˡᵈ
 
   # calculate residuum and do gradient step

--- a/src/FISTA.jl
+++ b/src/FISTA.jl
@@ -88,7 +88,7 @@ function init!(solver::FISTA{rT,vecT,matA,matAHA}, b::vecT
   else
     solver.x .= x
   end
-  solver.xᵒˡᵈ .= solver.x
+  solver.xᵒˡᵈ .= 0
 
   solver.t = t
   solver.tᵒˡᵈ = t

--- a/src/FISTA.jl
+++ b/src/FISTA.jl
@@ -139,7 +139,7 @@ function iterate(solver::FISTA, iteration::Int=0)
 
   # momentum / Nesterov step
   # this implementation mimics BART, saving memory by first swapping x and xᵒˡᵈ before calculating x + α * (x - xᵒˡᵈ)
-  for i ∈ eachindex(solver.x) # swap x and xᵒˡᵈ
+  @floop for i ∈ eachindex(solver.x) # swap x and xᵒˡᵈ
     tmp = solver.xᵒˡᵈ[i]
     solver.xᵒˡᵈ[i] = solver.x[i]
     solver.x[i] = tmp


### PR DESCRIPTION
Hi,
I have made several bugfixes to the existing FISTA implementation, which we have tested on simple 2D phantom testcase as well as our own 3D in vivo data in comparison to BART.
1. Calculation of the momentum term has been fixed, where it previously was computed based on the previous iterate's post-momentum x, as opposed to the pre-momentum x.
2. I moved the momentum update to the beginning of the loop, so that FISTA now correctly returns the x variable after the prox update, instead of after the momentum update
3. I changed the x initialization in `init!()` to be zero, instead of the hardcoded `solver.ρ * solver.x0`, so that the iteration # tracks correctly.

I have separately made small change to `proxLLR!()` and `proxLLRoverlapping!()` to incorporate a speedup trick introduced by Ong/Lustig's MSLR paper to avoid performing SVT operations on blocks whose maximum singular values, bounded by the matrix infinity norm, are lower than the supplied lambda, meaning the block should just be set to zeros.